### PR TITLE
add "-y" to "microdnf -y update"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 WORKDIR /opt/reaper/
 COPY pyproject.toml poetry.lock ./
 
-RUN microdnf update \
+RUN microdnf -y update \
     && microdnf -y install python3 python3-pip \
     && python3 -m pip install -U pip \
     && python3 -m pip install awscli \


### PR DESCRIPTION
This should fix builds that started failing last night when new packages for update started appearing in Red Hat's repos.